### PR TITLE
Fix compatibility with Levels & Wall Height (issue #66)

### DIFF
--- a/scripts/MeasuredTemplate.js
+++ b/scripts/MeasuredTemplate.js
@@ -128,6 +128,26 @@ function refreshMeasuredTemplate(template, flags) {
  * @param {PlaceableObject} object    The object instance being drawn
  */
 function drawMeasuredTemplate(template) {
+  // Add token elevation to the template if using Levels or Wall-Height modules
+  let moduleLevels = game.modules.get('levels');
+  let moduleWallHeight_active = game.modules.get('wall-height')?.active;
+  if ( moduleLevels && (moduleLevels.active || moduleWallHeight_active) ) {
+    // Copy the Levels method of getting the elevation so that the tool button for it is respected. Levels only sets its flags at preCreateMeasuredTemplate
+    if ( template.flags?.levels?.elevation !== undefined || template.flags?.[MODULE_ID]?.elevation !== undefined ) return;
+    const templateData = CONFIG.Levels.handlers.TemplateHandler.getTemplateData(false);
+    template.document.updateSource({
+      flags: { [MODULE_ID]: { elevation: templateData.elevation } }
+    });
+  } else if ( moduleWallHeight_active ) {
+    // If wall-height is active, but levels doesn't exist, we need a different approach. Take the elevation from the caster token
+    let parentToken = template.item?.parent ? template.item.parent.getActiveTokens().findLast((token, index) => token.controlled || index == 0 ) : canvas.tokens.controlled[0] ?? _token;
+    if ( parentToken ) {
+      template.document.updateSource({
+        flags: { [MODULE_ID]: { elevation: parentToken.document.elevation } }
+      });
+    }
+  }
+
   if ( !template.item ) return;
   addDnd5eItemConfigurationToTemplate(template);
 }

--- a/scripts/template_shapes/WalledTemplateShape.js
+++ b/scripts/template_shapes/WalledTemplateShape.js
@@ -243,13 +243,18 @@ export class WalledTemplateShape {
     // Add in elevation for Wall Height to use
     // Default to treating template as infinite in vertical directions
     // Do this after initialization b/c something is flipping them around. Likely Wall Height.
+    let wallHasBottomBelow = Number.POSITIVE_INFINITY;
+    let wallHasTopAbove = Number.NEGATIVE_INFINITY;
+    // If Levels or Wall-Height modules are active, use the elevation flags set by levels or this module
+    let elevation = this.template.document.getFlag('levels', 'elevation') ?? this.template.document.getFlag(MODULE_ID, 'elevation');
+    if ( elevation ) { wallHasBottomBelow = elevation; wallHasTopAbove = elevation; }
     cfg.source.object ??= {};
-    cfg.source.object.b ??= Number.POSITIVE_INFINITY;
-    cfg.source.object.t ??= Number.NEGATIVE_INFINITY;
+    cfg.source.object.b ??= wallHasBottomBelow;
+    cfg.source.object.t ??= wallHasTopAbove;
 
     // Need to also set origin, for reasons.
-    this.origin.b = Number.POSITIVE_INFINITY;
-    this.origin.t = Number.NEGATIVE_INFINITY;
+    this.origin.b = wallHasBottomBelow;
+    this.origin.t = wallHasTopAbove;
 
     let sweepClass = this.sweepClass;
     if ( sweepClass === LightWallSweep && !this.options.lastReflectedEdge) sweepClass = ClockwiseSweepShape;

--- a/scripts/template_shapes/WalledTemplateShape.js
+++ b/scripts/template_shapes/WalledTemplateShape.js
@@ -247,7 +247,7 @@ export class WalledTemplateShape {
     let wallHasTopAbove = Number.NEGATIVE_INFINITY;
     // If Levels or Wall-Height modules are active, use the elevation flags set by levels or this module
     let elevation = this.template.document.getFlag('levels', 'elevation') ?? this.template.document.getFlag(MODULE_ID, 'elevation');
-    if ( elevation ) { wallHasBottomBelow = elevation; wallHasTopAbove = elevation; }
+    if ( elevation !== undefined ) { wallHasBottomBelow = elevation; wallHasTopAbove = elevation; }
     cfg.source.object ??= {};
     cfg.source.object.b ??= wallHasBottomBelow;
     cfg.source.object.t ??= wallHasTopAbove;


### PR DESCRIPTION
I've put together a solution for the template preview and draw respecting the height of walls and using only walls that extend to the same elevation as the template.

This does not solve the issue that all tokens that are covered by the template are targeted, regardless of elevation (issue #67), but that is a separate thing to tackle.